### PR TITLE
fix footer for itn so there is no warning

### DIFF
--- a/chunks/create_itn_footer.md
+++ b/chunks/create_itn_footer.md
@@ -11,5 +11,3 @@
 <br>
 This content is free for noncommercial reuse with attribution. CC-BY-NC
 </div>
-
-<br>


### PR DESCRIPTION
The chairing and talk cheatsheets had a warning from me updating this chunk but not having a complete final line  (this is because these cheatsheets were updated/new). Kate added a warning suppressing statement to the talk cheatsheet #14 but this will test if the chairing cheatsheat looks ok now. 

`## Warning in readLines(doc_path): incomplete final line found on`
`## 'chunks/create_itn_footer.md'`